### PR TITLE
[03/13] 이동 플랫폼 로직 수정

### DIFF
--- a/Source/ObstacleAssault/MovingPlatform.cpp
+++ b/Source/ObstacleAssault/MovingPlatform.cpp
@@ -38,8 +38,11 @@ void AMovingPlatform::Tick(float DeltaTime)
 		// Reverse direction of motion if gone too far
 	if (DistanceMoved > LimitedDistance)
 	{
+		FVector MoveDirection = PlatformVelocity.GetSafeNormal();
+		StartLocation += MoveDirection * LimitedDistance;
+		SetActorLocation(StartLocation);
+
 		PlatformVelocity *= -1;
-		StartLocation = CurrentLocation;
 	}
 }
 


### PR DESCRIPTION
**시작점 업데이트 시의 문제점**
- if (DistanceMoved > LimitedDistance)
  - 이동 거리가 기준값보다 크기"만" 하면 되는 상황에서 시작점을 업데이트할 경우, 경로 이탈 가능성이 있음

→ 정확한 지점을 다시 StartLocation으로 설정하고, 해당 값을 Actor의 Location으로 설정